### PR TITLE
Navigation from main page

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -15,9 +15,20 @@
         <br />
       </div>
     </div>
-    <bigbutton label="START"></bigbutton>
-    <bigbutton label="HOW TO PLAY" theme="warning"></bigbutton>
-    <bigbutton label="ABOUT GAME" theme="info"></bigbutton>
+    <bigbutton
+      label="START"
+      @clicked="$router.push({ name: 'Game' })"
+    ></bigbutton>
+    <bigbutton
+      label="HOW TO PLAY"
+      theme="warning"
+      @clicked="$router.push({ name: 'HowToPlay' })"
+    ></bigbutton>
+    <bigbutton
+      label="ABOUT GAME"
+      theme="info"
+      @clicked="$router.push({ name: 'About' })"
+    ></bigbutton>
   </div>
 </template>
 

--- a/tests/e2e/specs/navigation.spec.js
+++ b/tests/e2e/specs/navigation.spec.js
@@ -1,0 +1,28 @@
+/// <reference types="Cypress" />
+
+describe('App navigation', () => {
+  context('from the main page', () => {
+    beforeEach(() => {
+      cy.visit('/')
+    })
+
+    it('navigates to game page on clicking START button', () => {
+      cy.get('button')
+        .contains('START')
+        .click()
+      cy.url().should('include', '/game')
+    })
+
+    it('navigates to the how to play page on clicking HOW TO PLAY button', () => {
+      cy.contains('button', 'HOW TO PLAY').click()
+      cy.url().should('include', '/howtoplay')
+    })
+
+    it('navigates to about page on clicking ABOUT button', () => {
+      cy.get('button')
+        .contains('ABOUT')
+        .click()
+      cy.url().should('include', '/about')
+    })
+  })
+})

--- a/tests/unit/views/Home.spec.js
+++ b/tests/unit/views/Home.spec.js
@@ -11,25 +11,25 @@ describe('Home.vue', () => {
 
   it('should show a button with START text', () => {
     let wrapper = shallowMount(Home)
-    let start_button = wrapper
+    let start_buttons = wrapper
       .findAll(BigButton)
       .filter(button => button.props('label') == 'START')
-    expect(start_button.length).toBe(1) // Did we find the button?
+    expect(start_buttons.length).toBe(1) // Did we find the button?
   })
 
   it('should show a button with HOW TO PLAY text', () => {
     let wrapper = shallowMount(Home)
-    let start_button = wrapper
+    let howtoplay_buttons = wrapper
       .findAll(BigButton)
       .filter(button => button.props('label') == 'HOW TO PLAY')
-    expect(start_button.length).toBe(1) // Did we find the button?
+    expect(howtoplay_buttons.length).toBe(1) // Did we find the button?
   })
 
   it('should should a button with ABOUT GAME text', () => {
     let wrapper = shallowMount(Home)
-    let start_button = wrapper
+    let about_buttons = wrapper
       .findAll(BigButton)
       .filter(button => button.props('label') == 'ABOUT GAME')
-    expect(start_button.length).toBe(1) // Did we find the button?
+    expect(about_buttons.length).toBe(1) // Did we find the button?
   })
 })


### PR DESCRIPTION
This patch adds the ability to navigate to different pages from the
home page. It adds cypress tests to confirm behaviour. A few unit
tests have been refactored to indicate that .filter() returns an
array.